### PR TITLE
nginx.conf: remove the automagical redirect http->https

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -47,10 +47,6 @@ http {
         add_header X-Frame-Options DENY;
         add_header X-Content-Type-Options nosniff;
 
-        # if 'http' was specified by mistake - redirect to https
-        # by overriding error_page for code 497 'Request Sent to HTTPS Port'
-        error_page 497 https://$http_host$request_uri;
-
         # extract the outside port env var
         set_by_lua $MAPPED_PORT 'return os.getenv("MAPPED_PORT")';
 


### PR DESCRIPTION
it creates confusing effects when someone indeed makes a mistake in url, e.g.:
- POST to /deployments (http) returns a 302
- user never sees it; the client automatically follows the redirect with https, but with a GET (HTTP 200)
- result: POST didn't work; 200 HTTP suggests success

to prevent debugging sessions in the future - from now on a regular 497
error will be returned.

Issues: MEN-599

Signed-off-by: mchalczynski marcin.chalczynski@rndity.com
