### PR TITLE
readme: updated to common template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,64 @@
-# API Gateway
+Mender API Gateway
+==============================================
 
-Dockerfile for the API Gateway based on NGINX, plus the relevant server configuration.
+Mender is an open source over-the-air (OTA) software updater for embedded Linux
+devices. Mender comprises a client running at the embedded device, as well as
+a server that manages deployments across many devices.
 
-It is a slightly customized version of the official nginx `mainline/debian/jessie` docker image:
-- using `nginx-extras` instead of the basic `nginx` (e.g. for embedded lua scripting)
-- removed unused packages from `apt-get install`
+This repository contains the Mender API Gateway, which is part of the
+Mender server. The Mender server is designed as a microservices architecture
+and comprises several repositories.
 
-The gateway has two responsibilities:
+The API Gateway serves as an entrypoint for all HTTP communication with Mender. Its main responsibility is the proxying of requests to Mender services, while rewriting URLs from a public API scheme to an internal one. The gateway also enforces authentication upon every request.
 
-- proxying requests to Mender services while rewriting URLs from a public API scheme to an internal one
-- automatically routing selected requests to auth verification endpoints before passing them on
+![Mender logo](https://mender.io/user/pages/04.resources/_logos/logoS.png)
 
-# Proxying and URL rewriting
 
-Mender APIs are accessible via the following public URL scheme:
+## Getting started
 
-`/api/<target>/<version>/<service>/<resource>...`
+To start using Mender, we recommend that you begin with the Getting started
+section in [the Mender documentation](https://docs.mender.io/).
 
-where:
-- `target` selects the internally enforced auth method and is one of:
-    - `devices` - for device-originating requests
-    - `integrations` - for web UIs
 
-- `version` is of the `maj.min` format
+## Building from source
 
-- `service` is the service selector, currently supported:
-    - `admission`
-    - `authentication`
-    - `deployments`
+As the Mender server is designed as microservices architecture, it requires several
+repositories to be built to be fully functional. If you are testing the Mender server it
+is therefore easier to follow the getting started section above as it integrates these
+services.
 
-- `resource` is the service resource/method, basically the 'rest' of the URL, and is passed verbatim to the selected service
-
-Examples:
-
-`POST /api/devices/0.1/authentication/auth_requests`
-
-`GET /api/integrations/0.1/admission/devices`
-
-As a consequence of URL rewriting, the gateway also rewrites all URLs in headers returned from services to the public scheme, so that they can be readily followed by the client.
-
-# HTTPS
-
-The gateway enforces HTTPS-only traffic; a self-signed Mender Software certificate, embedded in the gateway image, is used for this purpose by default.
-The user can retrieve this certificate to make it available to devices, or override it with a custom certificate (self-signed or otherwise); both procedures are described below.
-
-## Obtaining the certificate
-
-The certificate file path inside the running container is:
-
-`/var/www/mendersoftware/cert/cert.pem`
-
-To copy this file to the local filesystem, run the [docker cp](https://docs.docker.com/engine/reference/commandline/cp/) command:
-
-`sudo docker cp integration_mender-api-gateway_1:/var/www/mendersoftware/cert/cert.pem /local/path/to/cert/`
-
-## Substituting the certificate
-
-A custom certificate and key can be provided to the container via a mounted Docker volume.
-The relevant paths inside the container are as follows:
-
-- `/var/www/mendersoftware/cert/cert.pem`
-- `/var/www/mendersoftware/cert/key.pem`
-
-Override these files by adding the following volumes into `docker-compose.yaml`:
+If you would like to build th Mender API Gateway independently, you can follow
+these steps:
 
 ```
-    mender-api-gateway:
-        ...
-        volumes:
-            - /local/path/to/cert.pem:/var/www/mendersoftware/cert/cert.pem
-            - /local/path/to/key.pem:/var/www/mendersoftware/cert/key.pem
-        ...
+git clone https://github.com/mendersoftware/mender-api-gateway-docker.git
+cd mender-api-gateway-docker
+sudo docker build -t mendersoftware/api-gateway .
 ```
-The gateway must be restarted for these changes to take effect.
 
-### Generating a self-signed certificate
+## Contributing
 
-A self-signed certificate can be generated with the `openssl` command e.g. as follows:
+We welcome and ask for your contribution. If you would like to contribute to Mender, please read our guide on how to best get started [contributing code or
+documentation](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md).
 
-`openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes`
+## License
 
-For details consult the openssl manual.
+Mender is licensed under the Apache License, Version 2.0. See
+[LICENSE](https://github.com/mendersoftware/mender-api-gateway-docker/blob/master/LICENSE) for the
+full license text.
 
-# Authentication
+## Security disclosure
 
-The gateway enforces authentication by first routing requests to a dedicated auth verification endpoint (via the `auth_request` module):
+We take security very seriously. If you come across any issue regarding
+security, please disclose the information by sending an email to
+[security@mender.io](security@mender.io). Please do not create a new public
+issue. We thank you in advance for your cooperation.
 
-- `devices` requests are verified via devauth's `tokens/verify` endpoint
-- `integrations` requests are currently not authenticated at all; they will have a dedicated auth service in the future
+## Connect with us
 
-# Requirements
-- the image requires all services to be up and running and accessible by their domain names; the name resolution happens at nginx startup, if it fails - the container exits (it only makes sense to run the container in `integration`)
-
-- as usual it's useful to map some ports:
-    - `80` for `http` (this is used for now)
-    - `443` for `https`
-
-- the `MAPPED_PORT` env var, containing the number of the mapped `http` port, must be passed to the container (nginx doesn't know the outside port and will use 80 for all header rewriting otherwise)
+* Join our [Google
+  group](https://groups.google.com/a/lists.mender.io/forum/#!forum/mender)
+* Follow us on [Twitter](https://twitter.com/mender_io?target=_blank). Please
+  feel free to tweet us questions.
+* Fork us on [Github](https://github.com/mendersoftware)
+* Email us at [contact@mender.io](mailto:contact@mender.io)


### PR DESCRIPTION
Issues: MEN-645

Signed-off-by: mchalczynski marcin.chalczynski@rndity.com

after some back and forth I decided to go for a very slim version of this readme. additional info like:
- the mechanism of url scheme rewriting
- instructions regarding https certs (obtaining, generation, substition)
- \+ a couple of even more obscure details

was just making it messy (a lot of stuff to include).

I suppose these are good candidates for a dedicated doc on docs.mender.io. @eysteins do you intend to include them there?  

I'll get back to it after your feedback, in the meantime moving on to other tasks (this is the last of the bunch of READMEs).
