### PR TITLE
nginx: image size limit increased

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -135,9 +135,9 @@ http {
         }
 
         # deployments
-        location ~ /api/integrations/0.1/deployments/images/(?<id>.*) {
+        location ~ /api/integrations/0.1/deployments/images {
             client_max_body_size 10G;
-            rewrite ^.*$ /api/0.0.1/images/$id break;
+            rewrite ^.*$ /api/0.0.1/images break;
             proxy_redirect ~^.*/api/0.0.1/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/deployments/$1;
             proxy_pass http://mender-deployments:8080;
         }


### PR DESCRIPTION
Image upload rule changed.
Image upload endpoint is:
POST /api/integrations/0.1/deployments/images

@mchalski @marekswiecznik
