### PR TITLE
nginx: more specific /api/integrations/0.1/deployments/images match

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -135,7 +135,7 @@ http {
         }
 
         # deployments
-        location ~ /api/integrations/0.1/deployments/images {
+        location ~ /api/integrations/0.1/deployments/images$ {
             client_max_body_size 10G;
             rewrite ^.*$ /api/0.0.1/images break;
             proxy_redirect ~^.*/api/0.0.1/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/deployments/$1;


### PR DESCRIPTION
API /deployments/images endpoint has a specific configuration setup.
However, due to the location URL match not being specific enough,
requests going to /deployments/images/<id>, or
/deployments/images/<id>/download would still be caught by that rule and
routed to incorrect endpoint of deployments service.

@kjaskiewiczz @marekswiecznik @maciejmrowiec @mchalski 