### PR TITLE
nginx: setup routing for useradm service

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -95,6 +95,18 @@ http {
         # /api/integrations/0.1/admission -> mender-device-adm/api/0.1.0/...
         # /api/integrations/0.0/deployments/... -> mender-deployments:8080/api/0.0.1/...
 
+        # user authz endpoint
+        location /api/integrations/0.1/useradm/auth/login{
+            proxy_pass http://mender-useradm:8080/api/0.1.0/auth/login;
+        }
+
+        # user administration
+        location ~ /api/integrations/0.1/useradm(?<endpoint>/.*){
+            rewrite ^.*$ /api/0.1.0$endpoint break;
+            proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/useradm/$1;
+            proxy_pass http://mender-useradm:8080;
+        }
+
         # device admission
         location ~ /api/integrations/0.1/admission(?<endpoint>/.*){
             rewrite ^.*$ /api/0.1.0$endpoint break;


### PR DESCRIPTION
API routing for useradm service. Separate /auth/login endpoint for user
logins.

@mendersoftware/rndity @maciejmrowiec 