### PR TITLE
userauth verify & enhancements

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -168,7 +168,7 @@ http {
 
         # this is our verification endpoint definition (alias over /devauth/tokens/verify)
         # used only internally to authenticate device requests (not a real endpoint)
-        location /devauth {
+        location = /devauth {
             internal;
             proxy_method POST; #default would be GET, but our endpoint doesn't accept that
             proxy_pass http://mender-device-auth:8080/api/0.1.0/tokens/verify;

--- a/nginx.conf
+++ b/nginx.conf
@@ -102,6 +102,8 @@ http {
 
         # user administration
         location ~ /api/integrations/0.1/useradm(?<endpoint>/.*){
+            auth_request /userauth;
+
             rewrite ^.*$ /api/0.1.0$endpoint break;
             proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/useradm/$1;
             proxy_pass http://mender-useradm:8080;
@@ -109,6 +111,8 @@ http {
 
         # device admission
         location ~ /api/integrations/0.1/admission(?<endpoint>/.*){
+            auth_request /userauth;
+
             rewrite ^.*$ /api/0.1.0$endpoint break;
 
             proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/admission/$1;
@@ -148,12 +152,16 @@ http {
 
         # deployments
         location ~ /api/integrations/0.1/deployments/images$ {
+            auth_request /userauth;
+
             client_max_body_size 10G;
             rewrite ^.*$ /api/0.0.1/images break;
             proxy_redirect ~^.*/api/0.0.1/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/deployments/$1;
             proxy_pass http://mender-deployments:8080;
         }
         location ~ /api/integrations/0.1/deployments(?<endpoint>/.*){
+            auth_request /userauth;
+
             rewrite ^.*$ /api/0.0.1$endpoint break;
             proxy_redirect ~^.*/api/0.0.1/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/deployments/$1;
             proxy_pass http://mender-deployments:8080;
@@ -161,6 +169,8 @@ http {
 
         # inventory
         location ~ /api/integrations/0.1/inventory(?<endpoint>/.*){
+            auth_request /userauth;
+
             rewrite ^.*$ /api/0.1.0$endpoint break;
             proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/inventory/$1;
             proxy_pass http://mender-inventory:8080;

--- a/nginx.conf
+++ b/nginx.conf
@@ -176,6 +176,16 @@ http {
             proxy_set_header Content-Length "";
         }
 
+        # case similar to /devauth but this time for user verification
+        location = /userauth {
+            internal;
+            proxy_method POST;
+            proxy_pass http://mender-useradm:8080/api/0.1.0/auth/verify;
+            proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
+            proxy_set_header X-Original-URI $request_uri;
+        }
+
         # UI
         location = /ui {
             return 301 https://$host:$MAPPED_PORT/ui/;

--- a/nginx.conf
+++ b/nginx.conf
@@ -172,6 +172,8 @@ http {
             internal;
             proxy_method POST; #default would be GET, but our endpoint doesn't accept that
             proxy_pass http://mender-device-auth:8080/api/0.1.0/tokens/verify;
+            proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
         }
 
         # UI


### PR DESCRIPTION
Commit  50191fb643b7b3955f4338568034c3c2714364d5 should go along with https://github.com/mendersoftware/useradm/pull/8 as this will setup routing for token verification for all API endpoints, but we will hit a /token/verify stub implementation where all requests are accepted.

Additionally, the URI of incoming request is included in X-Original-URI header. This should allow us to verify and authorize requests.

commit 50191fb643b7b3955f4338568034c3c2714364d5
Author: Maciej Borzecki <maciej.borzecki@rndity.com>
Date:   Wed Nov 30 14:07:36 2016 +0100

    nginx: setup request authorization for integrations API endpoints
    
    Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>

commit 985ade0dc517b0d8858d652464473d66a30207dc
Author: Maciej Borzecki <maciej.borzecki@rndity.com>
Date:   Wed Nov 30 14:04:08 2016 +0100

    nginx: userauth: internal endpoint for user verification
    
    Set up an internal endpoint for user verification. Skip request body and reset
    Content-Length header as authentication data is not transported in request body.
    
    Include the URI of original request in X-Original-URI header.
    
    Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>

commit 95b477f4f83c87cc29eedc5a706b3ced73e733e2
Author: Maciej Borzecki <maciej.borzecki@rndity.com>
Date:   Wed Nov 30 14:02:30 2016 +0100

    ngingx: devauth: do not pass request body, reset Content-Length
    
    Device authorization data is contained in headers, hence request body (along
    with Content-Length) can be skipped when proxying auth.
    
    Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>

commit 02a259a9abfcb0f565b654748d8a8b737c798d41
Author: Maciej Borzecki <maciej.borzecki@rndity.com>
Date:   Wed Nov 30 13:59:42 2016 +0100

    nginx: use exact match modfier for /devauth
    
    Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>

@mendersoftware/rndity @maciejmrowiec 