### PR TITLE
nginx: userauth: disable client_max_body_size check for /userauth

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -189,6 +189,7 @@ http {
         # case similar to /devauth but this time for user verification
         location = /userauth {
             internal;
+            client_max_body_size 0;
             proxy_method POST;
             proxy_pass http://mender-useradm:8080/api/0.1.0/auth/verify;
             proxy_pass_request_body off;


### PR DESCRIPTION
Intergrations API requests are routed through internal endpoint /userauth.

When a POST to /deployments/images hits this endpoint, the subrequset to
/useauth fails due to client_max_body_size check. This is hard to explain, as
the endpoint is configured to *drop* the body of original request. As a
workaround, allow body of any size, but keep the policy of removing it from a
forwarded auth request.

@mendersoftware/rndity @maciejmrowiec 

@pasinskim please verify this PR in your integration tests and report back the status.