### PR TITLE
nginx: image artifact upload

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -155,6 +155,12 @@ http {
             auth_request /userauth;
 
             client_max_body_size 10G;
+
+            # do not buffer incoming upload requests into an intermediate file,
+            # deployments service performs an upload to storage engine while
+            # receiving the file from the client
+            proxy_request_buffering off;
+
             rewrite ^.*$ /api/0.0.1/images break;
             proxy_redirect ~^.*/api/0.0.1/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/deployments/$1;
             proxy_pass http://mender-deployments:8080;


### PR DESCRIPTION
Disable buffering of image upload to a temporary file. This should prevent nginx
and client from reaching a timeout while waiting for deployments service to
upload the image to starge backend.

@mendersoftware/rndity @GregorioDiStefano @maciejmrowiec 

Edit: If you're running a compose setup on a single host and try to upload 10GB image, nginx is first to buffer the image, then deployments buffers the image, reaching 20GB at its peak. With this change we will end up with a single 10GB buffered file.