### PR TITLE
Reverting the change that enforced user auth for every API endpoint.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -102,7 +102,8 @@ http {
 
         # user administration
         location ~ /api/integrations/0.1/useradm(?<endpoint>/.*){
-            auth_request /userauth;
+            #disable for now to be able to run integration tests
+            #auth_request /userauth;
 
             rewrite ^.*$ /api/0.1.0$endpoint break;
             proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/useradm/$1;
@@ -111,7 +112,8 @@ http {
 
         # device admission
         location ~ /api/integrations/0.1/admission(?<endpoint>/.*){
-            auth_request /userauth;
+            #disable for now to be able to run integration tests
+            #auth_request /userauth;
 
             rewrite ^.*$ /api/0.1.0$endpoint break;
 
@@ -152,7 +154,8 @@ http {
 
         # deployments
         location ~ /api/integrations/0.1/deployments/images$ {
-            auth_request /userauth;
+            #disable for now to be able to run integration tests
+            #auth_request /userauth;
 
             client_max_body_size 10G;
 
@@ -166,7 +169,8 @@ http {
             proxy_pass http://mender-deployments:8080;
         }
         location ~ /api/integrations/0.1/deployments(?<endpoint>/.*){
-            auth_request /userauth;
+            #disable for now to be able to run integration tests
+            #auth_request /userauth;
 
             rewrite ^.*$ /api/0.0.1$endpoint break;
             proxy_redirect ~^.*/api/0.0.1/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/deployments/$1;
@@ -175,7 +179,8 @@ http {
 
         # inventory
         location ~ /api/integrations/0.1/inventory(?<endpoint>/.*){
-            auth_request /userauth;
+            #disable for now to be able to run integration tests 
+            #auth_request /userauth;
 
             rewrite ^.*$ /api/0.1.0$endpoint break;
             proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/inventory/$1;


### PR DESCRIPTION
The rest of the system is lagging behind,
so the task cannot be completed at this time.
We need to revert once the `Create Tenant administrator` epic is
finished.

Signed-off-by: Marcin Pasinski <marcin.pasinski@cfengine.com>