### PR TITLE
nginx: enable listening on non SSL wrapped port

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -28,6 +28,7 @@ http {
     #gzip  on;
 
     server {
+        listen 80;
         listen 443 ssl http2;
         server_name localhost;
 


### PR DESCRIPTION
Setup listening on non SSL wrapped port to ease debugging. The port is not published by default, so unless someone explicitly publishes is to the outside world, it will remain inaccessible.

@mendersoftware/rndity @maciejmrowiec @GregorioDiStefano 