### PR TITLE
routing: changed 'integrations' URLs to 'management'

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -74,7 +74,7 @@ http {
         }
         location ~ /api/devices/0.1/deployments/device/deployments/(?<depid>.*)/log{
             auth_request /devauth;
-            client_max_body_size 10M; 
+            client_max_body_size 10M;
             rewrite ^.*$ /api/0.0.1/device/deployments/$depid/log break;
             proxy_pass http://mender-deployments:8080;
         }
@@ -93,32 +93,32 @@ http {
         # the following locations are for requests to our APIs from UIs, etc
         # no auth
         # examples:
-        # /api/integrations/0.1/admission -> mender-device-adm/api/0.1.0/...
-        # /api/integrations/0.0/deployments/... -> mender-deployments:8080/api/0.0.1/...
+        # /api/management/0.1/admission -> mender-device-adm/api/0.1.0/...
+        # /api/management/0.0/deployments/... -> mender-deployments:8080/api/0.0.1/...
 
         # user authz endpoint
-        location /api/integrations/0.1/useradm/auth/login{
+        location /api/management/0.1/useradm/auth/login{
             proxy_pass http://mender-useradm:8080/api/0.1.0/auth/login;
         }
 
         # user administration
-        location ~ /api/integrations/0.1/useradm(?<endpoint>/.*){
+        location ~ /api/management/0.1/useradm(?<endpoint>/.*){
             #disable for now to be able to run integration tests
             #auth_request /userauth;
 
             rewrite ^.*$ /api/0.1.0$endpoint break;
-            proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/useradm/$1;
+            proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/management/0.1/useradm/$1;
             proxy_pass http://mender-useradm:8080;
         }
 
         # device admission
-        location ~ /api/integrations/0.1/admission(?<endpoint>/.*){
+        location ~ /api/management/0.1/admission(?<endpoint>/.*){
             #disable for now to be able to run integration tests
             #auth_request /userauth;
 
             rewrite ^.*$ /api/0.1.0$endpoint break;
 
-            proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/admission/$1;
+            proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/management/0.1/admission/$1;
 
             # no sane way of transforming multi-valued headers in vanilla nginx
             # need to drop down to inline lua for this
@@ -129,7 +129,7 @@ http {
                 if k == "link" then
                     local new_base = ngx.var.scheme .. "://" ..
                                      ngx.var.host .. ":" .. os.getenv("MAPPED_PORT") ..
-                                     "/api/integrations/0.1/admission/"
+                                     "/api/management/0.1/admission/"
                     local link_regex = "<.*/api/(.*?)/(.*)>"
                     local new_link = "<" .. new_base .. "$2" .. ">"
 
@@ -154,7 +154,7 @@ http {
         }
 
         # deployments
-        location ~ /api/integrations/0.1/deployments/artifacts$ {
+        location ~ /api/management/0.1/deployments/artifacts$ {
             #disable for now to be able to run integration tests
             #auth_request /userauth;
 
@@ -166,25 +166,25 @@ http {
             proxy_request_buffering off;
 
             rewrite ^.*$ /api/0.0.1/artifacts break;
-            proxy_redirect ~^.*/api/0.0.1/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/deployments/$1;
+            proxy_redirect ~^.*/api/0.0.1/(.*)$ $scheme://$host:$MAPPED_PORT/api/management/0.1/deployments/$1;
             proxy_pass http://mender-deployments:8080;
         }
-        location ~ /api/integrations/0.1/deployments(?<endpoint>/.*){
+        location ~ /api/management/0.1/deployments(?<endpoint>/.*){
             #disable for now to be able to run integration tests
             #auth_request /userauth;
 
             rewrite ^.*$ /api/0.0.1$endpoint break;
-            proxy_redirect ~^.*/api/0.0.1/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/deployments/$1;
+            proxy_redirect ~^.*/api/0.0.1/(.*)$ $scheme://$host:$MAPPED_PORT/api/management/0.1/deployments/$1;
             proxy_pass http://mender-deployments:8080;
         }
 
         # inventory
-        location ~ /api/integrations/0.1/inventory(?<endpoint>/.*){
-            #disable for now to be able to run integration tests 
+        location ~ /api/management/0.1/inventory(?<endpoint>/.*){
+            #disable for now to be able to run integration tests
             #auth_request /userauth;
 
             rewrite ^.*$ /api/0.1.0$endpoint break;
-            proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/integrations/0.1/inventory/$1;
+            proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/management/0.1/inventory/$1;
             proxy_pass http://mender-inventory:8080;
         }
 


### PR DESCRIPTION
the change was tested manually by poking all services and their various APIs. for sure this was not a 100% check, but since not a single real issue was spotted (aside from the usual outdated docker images randomly flaking out, etc.), IMO the change seems correct. of course this is to be confirmed by integration tests.

Issues: MEN-825

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@maciejmrowiec @kjaskiewiczz @bboozzoo 