### PR TITLE
nginx: embed original request method in X-Original-Method when proxying to /auth/verify

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -207,6 +207,7 @@ http {
             proxy_pass_request_body off;
             proxy_set_header Content-Length "";
             proxy_set_header X-Original-URI $request_uri;
+            proxy_set_header X-Original-Method $request_method;
         }
 
         # UI


### PR DESCRIPTION
We're already passing original URI. Without knowing original request's method it might not be possible to take a reasonable decision about authorization.

@mendersoftware/rndity @maciejmrowiec 