### PR TITLE
Use temporary redirects for localhost.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -226,7 +226,13 @@ http {
 
         # redirect / to UI
         location = / {
-            return 301 https://$host:$MAPPED_PORT/ui/;
+            if ($host ~ "^localhost$") {
+                # Use temporary redirects in order to not "lock" the user's
+                # localhost to the address.
+                return 307 https://$host:$MAPPED_PORT/ui/;
+            } else {
+                return 301 https://$host:$MAPPED_PORT/ui/;
+            }
         }
 
     }


### PR DESCRIPTION
Use temporary redirects if the host name is localhost, otherwise any
other service the user launches at that address will not be reachable
because the browser auto-redirects to the gateway address. It's quite
tricky to reset this once it's happened.

Discovered when trying to view documentation locally inside a Docker
host; the browser was trying to access the gateway which was long
since torn down.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>