### PR TITLE
CORS again

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -188,7 +188,7 @@ http {
         # UI
         location = /ui {
             return 301 https://$host:$MAPPED_PORT/ui/;
-	    }
+        }
         location /ui {
             rewrite ^/ui/(.*)$ /$1 break;
             proxy_pass http://mender-gui:80;

--- a/nginx.conf
+++ b/nginx.conf
@@ -50,6 +50,11 @@ http {
         add_header X-Frame-Options DENY;
         add_header X-Content-Type-Options nosniff;
 
+        # more_set_headers cannot be used in server if block, and we want to
+        # avoid adding it to every location block, so we're going to set
+        # Access-Control-Allow-Origin on every 401 response
+        more_set_headers -s 401 "Access-Control-Allow-Origin: *";
+
         # extract the outside port env var
         set_by_lua $MAPPED_PORT 'return os.getenv("MAPPED_PORT")';
 


### PR DESCRIPTION
mostly this:
```
nginx: add Access-Control-Allow-Origin to every 401 status response

Responses carrying 4xx codes will be blocked by CORS functionality of the
browser or requests are made to a different origin. The response is expected to
carry Access-Control-Allow-Origin header that indicates if Origin used in the
original request is allowed to access particular resource. At the javascript
side, when blocked, xhr will not contain information about request status, in
particular status code will be 0.

Use `Headers More` module to set Access-Control-Allow-Origin on every 401
response. This should not cause problems for requests that are not CORS, and
will enable CORS requests to work. The setting is applied globally in `server`
block.
```

@mendersoftware/rndity @maciejmrowiec @michaelatmender 