### PR TITLE
TLS 1.0 is being gradually deprecated by major websites and TLS 1.1

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -35,10 +35,9 @@ http {
         ssl_certificate /var/www/mendersoftware/cert/cert.pem;
         ssl_certificate_key /var/www/mendersoftware/cert/key.pem;
 
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+        ssl_protocols TLSv1.1 TLSv1.2;
+        ssl_ciphers HIGH:!aNULL:!MD5:!SHA;
         ssl_prefer_server_ciphers on;
-        ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
-        ssl_ecdh_curve secp384r1;
         ssl_session_cache shared:SSL:10m;
         ssl_session_tickets off;
         ssl_stapling on;


### PR DESCRIPTION
is well supported in browsers.

Allow more ciphers; nginx uses a secure default cipherlist
(HIGH security only) and we should not require forward secrecy
only as this is expensive for an embedded device and not
that important for us (authenticity is the critical property).

This also enables use of Elliptic Curves.

Signed-off-by: Eystein Måløy Stenberg <eystein@mender.io>