### PR TITLE
entrypoint: update key/cert locations

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-CERT_PATH=/var/www/mendersoftware/cert/cert.pem
-KEY_PATH=/var/www/mendersoftware/cert/key.pem
+CERT_PATH=/var/www/mendersoftware/cert/cert.crt
+KEY_PATH=/var/www/mendersoftware/cert/private.key
 
 waserr=0
 for f in $CERT_PATH $KEY_PATH; do


### PR DESCRIPTION
Commit bce603ac14140bdb3aea55257d18c9fae44e6418 changes the location of
certificate and private key. Entrypoint helper that checks if these are present
at specific locations was not updated though.

@mendersoftware/rndity @maciejmrowiec 