### PR TITLE
Remove unnecessary redirects and 'MAPPED_PORT' variable from environment

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -18,18 +18,6 @@ and compiled manually, since `apk` doesn't provide them either.
 Debian has a very convenient package `nginx-extras` with a lot of useful extensions
 prebuilt, so this distro was used instead.
 
-### Port mapping
-When run inside a container, nginx does not know about the external port mappings
-assigned by Docker. The mapped port number is therefore passed via the `MAPPED_PORT`
-environment variable, so that URLs can be handled and translated correctly.
-
-The only port currently supported is 80, so this is what `MAPPED_PORT` points to.
-In the near future, all http communication will be disabled, so this will be
-moved to 443.
-
-The mapping problem can be solved with a more sophisticated approach (mounting docker's
-daemon socket + introspection), but the simplest solution was selected for now.
-
 ## nginx.conf
 
 This is the single place where proxying, authentication and URL rewriting happens.

--- a/nginx.conf
+++ b/nginx.conf
@@ -7,9 +7,6 @@ events {
     worker_connections  1024;
 }
 
-# declare the outside port env var, passed by docker-compose
-env MAPPED_PORT;
-
 http {
     include       /usr/local/openresty/nginx/conf/mime.types;
     default_type  application/octet-stream;
@@ -53,9 +50,6 @@ http {
         # avoid adding it to every location block, so we're going to set
         # Access-Control-Allow-Origin on every 401 response
         more_set_headers -s 401 "Access-Control-Allow-Origin: *";
-
-        # extract the outside port env var
-        set_by_lua $MAPPED_PORT 'return os.getenv("MAPPED_PORT")';
 
         # the following locations are for device-originating requests to our APIs
         # we route selected requests to devauth via the 'auth_request' module
@@ -115,7 +109,6 @@ http {
             auth_request /userauth;
 
             rewrite ^.*$ /api/0.1.0$endpoint break;
-            proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/management/0.1/useradm/$1;
             proxy_pass http://mender-useradm:8080;
         }
 
@@ -125,7 +118,6 @@ http {
 
             rewrite ^.*$ /api/0.1.0$endpoint break;
 
-            proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/management/0.1/admission/$1;
 
             proxy_pass http://mender-device-adm:8080;
         }
@@ -142,14 +134,12 @@ http {
             proxy_request_buffering off;
 
             rewrite ^.*$ /api/0.0.1/artifacts break;
-            proxy_redirect ~^.*/api/0.0.1/(.*)$ $scheme://$host:$MAPPED_PORT/api/management/0.1/deployments/$1;
             proxy_pass http://mender-deployments:8080;
         }
         location ~ /api/management/0.1/deployments(?<endpoint>/.*){
             auth_request /userauth;
 
             rewrite ^.*$ /api/0.0.1$endpoint break;
-            proxy_redirect ~^.*/api/0.0.1/(.*)$ $scheme://$host:$MAPPED_PORT/api/management/0.1/deployments/$1;
             proxy_pass http://mender-deployments:8080;
         }
 
@@ -158,7 +148,6 @@ http {
             auth_request /userauth;
 
             rewrite ^.*$ /api/0.1.0$endpoint break;
-            proxy_redirect ~^.*/api/0.1.0/(.*)$ $scheme://$host:$MAPPED_PORT/api/management/0.1/inventory/$1;
             proxy_pass http://mender-inventory:8080;
         }
 
@@ -191,8 +180,9 @@ http {
 
         # UI
         location = /ui {
-            return 301 https://$host:$MAPPED_PORT/ui/;
+            return 301 /ui/;
         }
+
         location /ui {
             rewrite ^/ui/(.*)$ /$1 break;
             proxy_pass http://mender-gui:80;
@@ -200,7 +190,7 @@ http {
 
         # redirect / to UI
         location = / {
-            return 301 https://$host:$MAPPED_PORT/ui/;
+            return 301 /ui/;
         }
 
     }


### PR DESCRIPTION
There is no need to use proxy redirects anymore, because all services are using relative locations in location headers.
'MAPPED_PORT' is no longer used.

@bboozzoo @maciejmrowiec @mchalski 