### PR TITLE
Revert "Redirect 0.1 version to v1 of Devices API. Temporary for grad…

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -52,11 +52,6 @@ http {
         # Access-Control-Allow-Origin on every 401 response
         more_set_headers -s 401 "Access-Control-Allow-Origin: *";
 
-        # redirect Devices API 0.1 version to Devices API v1
-        # temporary solution to support both version types in transition period
-        # should be removed!
-        rewrite ^/api/devices/0.1/(.*)$ /api/devices/v1/$1;
-
         # the following locations are for device-originating requests to our APIs
         # we route selected requests to devauth via the 'auth_request' module
         # we also transform the url scheme:


### PR DESCRIPTION
…ually switch to new versioning while not breaking testing."

Client have been ported to new version, no need to keep this redirect.

This reverts commit 33229ea230f5ea0bbcee4fe00cc83411486a6037.