### PR TITLE
nginx: export management endpoints of device authentication service

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -123,6 +123,25 @@ http {
             proxy_pass http://mender-useradm:8080;
         }
 
+        # device authentication
+       location /api/management/v1/devauth/{
+
+            location = /api/management/v1/devauth/auth_requests{
+                return 404;
+            }
+
+            location = /api/management/v1/devauth/tokens/verify{
+                return 404;
+            }
+
+            location ~ /api/management/v1/devauth(?<endpoint>/.*){
+                auth_request /userauth;
+
+                rewrite ^.*$ /api/0.1.0$endpoint break;
+                proxy_pass http://mender-device-auth:8080;
+            }
+       }
+
         # device admission
         location ~ /api/management/v1/admission(?<endpoint>/.*){
             auth_request /userauth;


### PR DESCRIPTION
Expose management endpoints, block device-only endpoints.

Enables use of:
https://github.com/mendersoftware/deviceauth/pull/109

@mendersoftware/rndity @maciejmrowiec 
