### PR TITLE
nginx: adjust proxy settings for deviceauth URL changes

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -60,8 +60,8 @@ http {
         # /api/devices/v1/deployments/... -> mender-deployments:8080/api/0.0.1/...
 
         # device authentication
-        location /api/devices/v1/authentication/auth_requests{
-            proxy_pass http://mender-device-auth:8080/api/0.1.0/auth_requests;
+        location /api/devices/v1/authentication/{
+            proxy_pass http://mender-device-auth:8080;
         }
 
         # deployments
@@ -124,22 +124,10 @@ http {
         }
 
         # device authentication
-       location /api/management/v1/devauth/{
+       location ~ /api/management/(v[0-9]+)/devauth/{
+            auth_request /userauth;
 
-            location = /api/management/v1/devauth/auth_requests{
-                return 404;
-            }
-
-            location = /api/management/v1/devauth/tokens/verify{
-                return 404;
-            }
-
-            location ~ /api/management/v1/devauth(?<endpoint>/.*){
-                auth_request /userauth;
-
-                rewrite ^.*$ /api/0.1.0$endpoint break;
-                proxy_pass http://mender-device-auth:8080;
-            }
+            proxy_pass http://mender-device-auth:8080;
        }
 
         # device admission
@@ -184,7 +172,7 @@ http {
         location = /devauth {
             internal;
             proxy_method POST; #default would be GET, but our endpoint doesn't accept that
-            proxy_pass http://mender-device-auth:8080/api/0.1.0/tokens/verify;
+            proxy_pass http://mender-device-auth:8080/api/internal/v1/devauth/tokens/verify;
             proxy_pass_request_body off;
             proxy_set_header Content-Length "";
         }


### PR DESCRIPTION
Device Authentication service URLs are now aligned wit the external API URLs.
Meaning that for management API URI we can just prefix match anything that comes
in and pass it directly to the services. For device URIs, use full URIs in
`location` blocks and similarly for device token verification endpoint.

@mendersoftware/rndity @maciejmrowiec 

Goes together with https://github.com/mendersoftware/deviceauth/pull/111