### PR TITLE
nginx: log and pass X-MEN-RequestID

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -13,7 +13,8 @@ http {
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+                      '"$http_user_agent" "$http_x_forwarded_for" '
+                      'request ID "$upstream_http_x_men_requestid"';
 
     access_log  /var/log/nginx/access.log  main;
 
@@ -67,26 +68,38 @@ http {
         # deployments
         location ~ /api/devices/v1/deployments/device/deployments/next{
             auth_request /devauth;
+            auth_request_set $requestid $upstream_http_x_men_requestid;
+
             # regex location needs a rewrite before proxy_pass
             rewrite ^.*$ /api/0.0.1/device/deployments/next break;
             proxy_pass http://mender-deployments:8080;
+            proxy_set_header X-MEN-RequestID $requestid;
         }
         location ~ /api/devices/v1/deployments/device/deployments/(?<depid>.*)/log{
             auth_request /devauth;
+            auth_request_set $requestid $upstream_http_x_men_requestid;
+
             client_max_body_size 10M;
             rewrite ^.*$ /api/0.0.1/device/deployments/$depid/log break;
             proxy_pass http://mender-deployments:8080;
+            proxy_set_header X-MEN-RequestID $requestid;
         }
         location ~ /api/devices/v1/deployments/device/deployments/(?<depid>.*)/status{
             auth_request /devauth;
+            auth_request_set $requestid $upstream_http_x_men_requestid;
+
             rewrite ^.*$ /api/0.0.1/device/deployments/$depid/status break;
             proxy_pass http://mender-deployments:8080;
+            proxy_set_header X-MEN-RequestID $requestid;
         }
 
         location ~ /api/devices/v1/inventory/device/attributes{
             auth_request /devauth;
+            auth_request_set $requestid $upstream_http_x_men_requestid;
+
             rewrite ^.*$ /api/0.1.0/attributes break;
             proxy_pass http://mender-inventory:8080;
+            proxy_set_header X-MEN-RequestID $requestid;
         }
 
         # the following locations are for requests to our APIs from UIs, etc
@@ -118,29 +131,36 @@ http {
         # user administration
         location ~ /api/management/v1/useradm(?<endpoint>/.*){
             auth_request /userauth;
+            auth_request_set $requestid $upstream_http_x_men_requestid;
 
             rewrite ^.*$ /api/0.1.0$endpoint break;
             proxy_pass http://mender-useradm:8080;
+            proxy_set_header X-MEN-RequestID $requestid;
         }
 
         # device authentication
        location ~ /api/management/(v[0-9]+)/devauth/{
             auth_request /userauth;
+            auth_request_set $requestid $upstream_http_x_men_requestid;
 
             proxy_pass http://mender-device-auth:8080;
+           proxy_set_header X-MEN-RequestID $requestid;
        }
 
         # device admission
         location ~ /api/management/v1/admission(?<endpoint>/.*){
             auth_request /userauth;
+            auth_request_set $requestid $upstream_http_x_men_requestid;
 
             rewrite ^.*$ /api/0.1.0$endpoint break;
             proxy_pass http://mender-device-adm:8080;
+            proxy_set_header X-MEN-RequestID $requestid;
         }
 
         # deployments
         location ~ /api/management/v1/deployments/artifacts$ {
             auth_request /userauth;
+            auth_request_set $requestid $upstream_http_x_men_requestid;
 
             client_max_body_size 10G;
 
@@ -151,20 +171,25 @@ http {
 
             rewrite ^.*$ /api/0.0.1/artifacts break;
             proxy_pass http://mender-deployments:8080;
+            proxy_set_header X-MEN-RequestID $requestid;
         }
         location ~ /api/management/v1/deployments(?<endpoint>/.*){
             auth_request /userauth;
+            auth_request_set $requestid $upstream_http_x_men_requestid;
 
             rewrite ^.*$ /api/0.0.1$endpoint break;
             proxy_pass http://mender-deployments:8080;
+            proxy_set_header X-MEN-RequestID $requestid;
         }
 
         # inventory
         location ~ /api/management/v1/inventory(?<endpoint>/.*){
             auth_request /userauth;
+            auth_request_set $requestid $upstream_http_x_men_requestid;
 
             rewrite ^.*$ /api/0.1.0$endpoint break;
             proxy_pass http://mender-inventory:8080;
+            proxy_set_header X-MEN-RequestID $requestid;
         }
 
         # this is our verification endpoint definition (alias over /devauth/tokens/verify)


### PR DESCRIPTION
Make sure that X-MEN-RequestID assigned by authentication endpoint is used for
subsequent proxy requests and logged in access log.

Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>

@mendersoftware/rndity @maciejmrowiec @GregorioDiStefano 