### PR TITLE
prevent host header injection

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,4 +16,11 @@ if [ "$waserr" = "1" ]; then
    exit 1
 fi
 
+if [ -n "$ALLOWED_HOSTS" ]; then
+    sed -i -e "s/[@]ALLOWED_HOSTS[@]/$ALLOWED_HOSTS/" /usr/local/openresty/nginx/conf/nginx.conf
+else
+   echo "ALLOWED_HOSTS undefined, exiting"
+   exit 1
+fi
+
 exec /usr/local/openresty/bin/openresty -g "daemon off;" $*

--- a/nginx.conf
+++ b/nginx.conf
@@ -30,6 +30,7 @@ http {
         listen 443 ssl http2;
         ssl_certificate /var/www/mendersoftware/cert/cert.crt;
         ssl_certificate_key /var/www/mendersoftware/cert/private.key;
+        ssl_session_tickets off;
 
         server_name _;
         return 444;

--- a/nginx.conf
+++ b/nginx.conf
@@ -24,6 +24,16 @@ http {
     keepalive_timeout  65;
 
     #gzip  on;
+    server {
+        listen 80;
+
+        listen 443 ssl http2;
+        ssl_certificate /var/www/mendersoftware/cert/cert.crt;
+        ssl_certificate_key /var/www/mendersoftware/cert/private.key;
+
+        server_name _;
+        return 444;
+    }
 
     server {
         listen 80;

--- a/nginx.conf
+++ b/nginx.conf
@@ -38,7 +38,7 @@ http {
     server {
         listen 80;
         listen 443 ssl http2;
-        server_name localhost;
+        server_name @ALLOWED_HOSTS@;
 
         ssl_certificate /var/www/mendersoftware/cert/cert.crt;
         ssl_certificate_key /var/www/mendersoftware/cert/private.key;
@@ -246,3 +246,4 @@ http {
 
     }
 }
+


### PR DESCRIPTION
Issues: https://tracker.mender.io/browse/MEN-1262

done via a standard technique of whitelisting known hostnames, and denying all requests which don't have a Host header, or the header points to an unknown host.

the whitelist is parametrized via a template variable + env var, so that it can be configured from compose files.

this needs:
https://github.com/mendersoftware/integration/pull/287
for int tests to pass
