### PR TITLE
reload: a dns monitor for periodic cache reloading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,15 @@ RUN mkdir -p /var/log/nginx && \
     ln -sf /dev/stdout /var/log/nginx/access.log && \
     ln -sf /dev/stderr /var/log/nginx/error.log
 
+RUN apk update && \
+apk add bind-tools
+
 EXPOSE 443
 
 COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 
 COPY entrypoint.sh /entrypoint.sh
+
+COPY reload-when-hosts-changed /reload-when-hosts-changed
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,4 +23,10 @@ else
    exit 1
 fi
 
+DNS_NAMES=${DNS_NAMES:-mender-useradm mender-inventory mender-deployments mender-device-auth mender-device-adm}
+
+echo "setting up automatic reload on host IP address changes for DNS names: $DNS_NAMES"
+
+./reload-when-hosts-changed $DNS_NAMES &
+
 exec /usr/local/openresty/bin/openresty -g "daemon off;" $*

--- a/reload-when-hosts-changed
+++ b/reload-when-hosts-changed
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+NAMES="$*"
+
+if [ -z "$NAMES" ]; then
+   echo "NAMES undefined, exiting"
+   exit 1
+fi
+
+while true; do
+    dig $NAMES |grep -v -e '^;' -v -e '^$' -v -e '^\.' > /tmp/addrs.new
+    if test -e /tmp/addrs; then
+         if ! cmp /tmp/addrs.new /tmp/addrs; then
+            /usr/local/openresty/bin/openresty -s reload
+            echo '-- reload'
+        fi
+    fi
+    mv /tmp/addrs.new /tmp/addrs
+    sleep 10
+done
+


### PR DESCRIPTION
since the 'resolver' approach didn't work, this is a workaround.

a standalone 'reload' script is introduced which periodically gets
dns names of known services. if changes are detected compared to a
previous run, '-s reload' is sent to openresty.

Issues: MEN-1227

Changelog: gateway dns cache reloading for improved recovery from service restarts

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@maciejmrowiec @mendersoftware/rndity 

also, see https://tracker.mender.io/browse/MEN-1227?focusedCommentId=81746&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-81746