### PR TITLE
Changelog: Include request time in gateway access logs.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -14,7 +14,8 @@ http {
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for" '
-                      'request ID "$upstream_http_x_men_requestid"';
+                      'request ID "$upstream_http_x_men_requestid" '
+                      '$request_time';
 
     access_log  /var/log/nginx/access.log  main;
 


### PR DESCRIPTION
Signed-off-by: Maciej Mrowiec <mrowiec.maciej@gmail.com>

@mendersoftware/rndity @GregorioDiStefano 

Today we are not able to poiunt out overall request service time. Adding to the log output.

