### PR TITLE
Changelog: Introuduce static content caching for /ui routing.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,6 @@ COPY entrypoint.sh /entrypoint.sh
 
 COPY reload-when-hosts-changed /reload-when-hosts-changed
 
+RUN mkdir -p /data/nginx/cache/ui
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,13 @@ else
    exit 1
 fi
 
+# Disabled by default
+if [ -n "$CACHE_UI" ]; then
+    sed -i -e "s/[@]CACHE_UI[@]/$CACHE_UI/" /usr/local/openresty/nginx/conf/nginx.conf
+else
+    sed -i -e "s/[@]CACHE_UI[@]/off/" /usr/local/openresty/nginx/conf/nginx.conf
+fi
+
 if [ -n "$HAVE_MULTITENANT" ]; then
     ln -sf /usr/local/openresty/nginx/conf/tenantadm.nginx.conf /usr/local/openresty/nginx/conf/optional/endpoints/tenantadm.nginx.conf
 fi

--- a/nginx.conf
+++ b/nginx.conf
@@ -265,8 +265,12 @@ http {
             
             proxy_cache ui_cache;
             proxy_cache_revalidate on;
+            proxy_ignore_headers Cache-Control Set-Cookie;
             proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
-            
+
+            proxy_cache_valid 200 301 302 30m;
+            proxy_cache_valid any 1m;
+
             add_header X-Cache-Status $upstream_cache_status;
 
             # UI application is in React.js all content is static.

--- a/nginx.conf
+++ b/nginx.conf
@@ -24,6 +24,9 @@ http {
 
     keepalive_timeout  65;
 
+    proxy_cache_path /data/nginx/cache/ui levels=1:2 keys_zone=ui_cache:10m max_size=100m
+                     inactive=1h use_temp_path=off;
+
     #gzip  on;
     server {
         listen 80;
@@ -259,6 +262,13 @@ http {
         }
 
         location /ui {
+            
+            proxy_cache ui_cache;
+            proxy_cache_revalidate on;
+            proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+            
+            add_header X-Cache-Status $upstream_cache_status;
+
             rewrite ^/ui/(.*)$ /$1 break;
             proxy_pass http://mender-gui:80;
         }

--- a/nginx.conf
+++ b/nginx.conf
@@ -269,6 +269,9 @@ http {
             
             add_header X-Cache-Status $upstream_cache_status;
 
+            # UI application is in React.js all content is static.
+            expires @CACHE_UI@;
+
             rewrite ^/ui/(.*)$ /$1 break;
             proxy_pass http://mender-gui:80;
         }


### PR DESCRIPTION
Add X-Cache-Status header for cached content.
Cache up to 100MB of content on disk.
Enable cache revalidation with origin server.
Serve stale cache when refreshing cache or experienceing origin server issues (additional fault tollerance).
Enable browser caching for /ui, configurable by CACHE_UI env. Default: disabled.

Signed-off-by: Maciej Mrowiec <mrowiec.maciej@gmail.com>

@mendersoftware/rndity 

UI is all static content.