### PR TITLE
nginx.conf: 1:1 routing for deviceadm

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -183,7 +183,6 @@ http {
             auth_request /userauth;
             auth_request_set $requestid $upstream_http_x_men_requestid;
 
-            rewrite ^.*$ /api/0.1.0$endpoint break;
             proxy_pass http://mender-device-adm:8080;
             proxy_set_header X-MEN-RequestID $requestid;
         }
@@ -256,7 +255,7 @@ http {
         }
 
         location /ui {
-            
+
             proxy_cache ui_cache;
             proxy_cache_revalidate on;
             proxy_ignore_headers Cache-Control Set-Cookie;


### PR DESCRIPTION
in preparation for actually enforcing mgmt vs internal apis

changelog: none

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

goes with https://github.com/mendersoftware/deviceadm/pull/110