### PR TITLE
Disable gateway caching by default. 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,10 +24,24 @@ else
 fi
 
 # Disabled by default
-if [ -n "$CACHE_UI" ]; then
-    sed -i -e "s/[@]CACHE_UI[@]/$CACHE_UI/" /usr/local/openresty/nginx/conf/nginx.conf
+if [ -n "$CACHE_UI_BROWSER_PERIOD" ]; then
+    sed -i -e "s/[@]CACHE_UI_BROWSER_PERIOD[@]/$CACHE_UI_BROWSER_PERIOD/" /usr/local/openresty/nginx/conf/nginx.conf
 else
-    sed -i -e "s/[@]CACHE_UI[@]/off/" /usr/local/openresty/nginx/conf/nginx.conf
+    sed -i -e "s/[@]CACHE_UI_BROWSER_PERIOD[@]/off/" /usr/local/openresty/nginx/conf/nginx.conf
+fi
+
+# Disabled by default
+if [ -n "$CACHE_UI_SUCCESS_PERIOD" ]; then
+    sed -i -e "s/[@]CACHE_UI_SUCCESS_PERIOD[@]/$CACHE_UI_SUCCESS_PERIOD/" /usr/local/openresty/nginx/conf/nginx.conf
+else
+    sed -i -e "s/[@]CACHE_UI_SUCCESS_PERIOD[@]/0s/" /usr/local/openresty/nginx/conf/nginx.conf
+fi
+
+# Disabled by default
+if [ -n "$CACHE_UI_FAILUE_PERIOD" ]; then
+    sed -i -e "s/[@]CACHE_UI_FAILURE_PERIOD[@]/$CACHE_UI_FAILURE_PERIOD/" /usr/local/openresty/nginx/conf/nginx.conf
+else
+    sed -i -e "s/[@]CACHE_UI_FAILURE_PERIOD[@]/0s/" /usr/local/openresty/nginx/conf/nginx.conf
 fi
 
 if [ -n "$HAVE_MULTITENANT" ]; then

--- a/nginx.conf
+++ b/nginx.conf
@@ -250,13 +250,13 @@ http {
             proxy_ignore_headers Cache-Control Set-Cookie;
             proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
 
-            proxy_cache_valid 200 301 302 30m;
-            proxy_cache_valid any 1m;
+            proxy_cache_valid 200 301 302 @CACHE_UI_SUCCESS_PERIOD@;
+            proxy_cache_valid any @CACHE_UI_FAILURE_PERIOD@;
 
             add_header X-Cache-Status $upstream_cache_status;
 
             # UI application is in React.js all content is static.
-            expires @CACHE_UI@;
+            expires @CACHE_UI_BROWSER_PERIOD@;
 
             rewrite ^/ui/(.*)$ /$1 break;
             proxy_pass http://mender-gui:80;


### PR DESCRIPTION
Introduce settings to configure and enable caching:

CACHE_UI_BROWSER_PERIOD - browser side cache persiod (1h, 1m ...)
CACHE_UI_SUCCESS_PERIOD - http 200 301 302 reponse cache time on gateway
CACHE_UI_BROWSER_PERIOD - other http statues reponse cache time on gateway

Changelog: none

Signed-off-by: Maciej Mrowiec <mrowiec.maciej@gmail.com>