### PR TITLE
introduce rate limits

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,20 @@ if [ -n "$HAVE_MULTITENANT" ]; then
        /usr/local/openresty/nginx/conf/optional/endpoints/tenantadm.nginx.conf
 fi
 
+# Rate limits - disabled by default
+if [ -n "$RATE_LIMIT_GLOBAL_RATE" ] && [ $RATE_LIMIT_GLOBAL_RATE -gt 0 ]; then
+    sed -i -e "s/[@]RATE_LIMIT_GLOBAL_RATE[@]/${RATE_LIMIT_GLOBAL_RATE}r\/s/" /usr/local/openresty/nginx/conf/nginx.conf
+
+    if [ -n "$RATE_LIMIT_GLOBAL_BURST" ] && [ $RATE_LIMIT_GLOBAL_BURST -gt 0 ]; then
+        sed -i -e "s/[@]RATE_LIMIT_GLOBAL_BURST[@]/burst=$RATE_LIMIT_GLOBAL_BURST/" /usr/local/openresty/nginx/conf/nginx.conf
+    else
+        sed -i -e "s/[@]RATE_LIMIT_GLOBAL_BURST[@] //" /usr/local/openresty/nginx/conf/nginx.conf
+    fi
+else
+    sed -i -e "/[@]RATE_LIMIT_GLOBAL_RATE[@]/d" /usr/local/openresty/nginx/conf/nginx.conf
+    sed -i -e "/[@]RATE_LIMIT_GLOBAL_BURST[@]/d" /usr/local/openresty/nginx/conf/nginx.conf
+fi
+
 DNS_NAMES=${DNS_NAMES:-mender-useradm mender-inventory mender-deployments \
                                       mender-device-auth mender-device-adm \
                                       mender-gui}

--- a/nginx.conf
+++ b/nginx.conf
@@ -27,6 +27,9 @@ http {
     proxy_cache_path /data/nginx/cache/ui levels=1:2 keys_zone=ui_cache:10m max_size=100m
                      inactive=1h use_temp_path=off;
 
+    limit_req_zone $binary_remote_addr zone=mylimit:10m rate=@RATE_LIMIT_GLOBAL_RATE@;
+    limit_req zone=mylimit @RATE_LIMIT_GLOBAL_BURST@ nodelay;
+
     #gzip  on;
     server {
         listen 80;


### PR DESCRIPTION
Issues: https://tracker.mender.io/browse/MEN-1718
From now on it is possible to set rate limit per IP address
for the API using environment variables.
There are two variables:
RATE_LIMIT_GLOBAL_RATE=limit - number of request per second
RATE_LIMIT_GLOBAL_BURST=burst - burst parameter defines
how many requests a client can make in excess
of the rate specified by the limit.Signed-off-by: Krzysztof Jaskiewicz <krzysiekjaskiewicz@gmail.com>
Both parameters, limit and burst, should be numbers.

@maciejmrowiec @GregorioDiStefano @mchalski 