### PR TITLE
nginx.conf adjust response code

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,6 +61,7 @@ if [ -n "$RATE_LIMIT_GLOBAL_RATE" ] && [ $RATE_LIMIT_GLOBAL_RATE -gt 0 ]; then
 else
     sed -i -e "/[@]RATE_LIMIT_GLOBAL_RATE[@]/d" /usr/local/openresty/nginx/conf/nginx.conf
     sed -i -e "/[@]RATE_LIMIT_GLOBAL_BURST[@]/d" /usr/local/openresty/nginx/conf/nginx.conf
+    sed -i -e "/limit_req_status/d" /usr/local/openresty/nginx/conf/nginx.conf
 fi
 
 DNS_NAMES=${DNS_NAMES:-mender-useradm mender-inventory mender-deployments \

--- a/nginx.conf
+++ b/nginx.conf
@@ -29,6 +29,7 @@ http {
 
     limit_req_zone $binary_remote_addr zone=mylimit:10m rate=@RATE_LIMIT_GLOBAL_RATE@;
     limit_req zone=mylimit @RATE_LIMIT_GLOBAL_BURST@ nodelay;
+    limit_req_status 429;
 
     #gzip  on;
     server {


### PR DESCRIPTION
nginx.conf: replace default rate limit response HTTP 503 (Service Temporarily Unavailable) with HTTP 429 (Too Many Requests)

When a client exceeds its rate limit gateway returns 429 (Too
Many Reqests) instead of 503 (Service Temporarily Unavailable)

Issue: https://tracker.mender.io/browse/MEN-1765

@maciejmrowiec @GregorioDiStefano @mchalski 