### PR TITLE
Changelog: Allow cross-origin requests from hostnames listed in ALLOW…

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,10 @@ fi
 
 if [ -n "$ALLOWED_HOSTS" ]; then
     sed -i -e "s/[@]ALLOWED_HOSTS[@]/$ALLOWED_HOSTS/" /usr/local/openresty/nginx/conf/nginx.conf
+
+    # generate ORIGIN whitelist
+    hosts=$(echo $ALLOWED_HOSTS | sed 's/ \{1,\}/|/g' | sed 's/[.]\{1,\}/\\\\\\./g')
+    sed -i -e "s/[@]ALLOWED_ORIGIN_HOSTS[@]/$hosts/" /usr/local/openresty/nginx/conf/nginx.conf
 else
    echo "ALLOWED_HOSTS undefined, exiting"
    exit 1

--- a/nginx.conf
+++ b/nginx.conf
@@ -70,6 +70,9 @@ http {
         if ($http_origin = $scheme://$host:$server_port) {
             set $origin_valid 1;
         }
+        if ($http_origin ~* ^((https?:\/\/)?(@ALLOWED_ORIGIN_HOSTS@))$) {
+            set $origin_valid 1;
+        }
         if ($origin_valid = 0) {
             return 400;
         }


### PR DESCRIPTION
…ED_HOSTS

Signed-off-by: Maciej Mrowiec <mrowiec.maciej@gmail.com>

@kjaskiewiczz @GregorioDiStefano  I think this one will do the trick:
Allow origins from any of the configured domains in allowed hosts (also cross-domains)