### PR TITLE
Avoid to expose internal hostname in headers link

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -181,6 +181,14 @@ http {
             auth_request /userauth;
             auth_request_set $requestid $upstream_http_x_men_requestid;
 
+            proxy_set_header X-Forwarded-Host $host:$server_port;
+            proxy_set_header X-Forwarded-Server $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+            proxy_set_header Host $host;
+            proxy_redirect off;
+
             proxy_pass http://mender-device-auth:8080;
             proxy_set_header X-MEN-RequestID $requestid;
         }
@@ -214,6 +222,15 @@ http {
             auth_request_set $requestid $upstream_http_x_men_requestid;
 
             rewrite ^.*$ /api/0.1.0$endpoint break;
+
+            proxy_set_header X-Forwarded-Host $host:$server_port;
+            proxy_set_header X-Forwarded-Server $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+            proxy_set_header Host $host;
+            proxy_redirect off;
+
             proxy_pass http://mender-inventory:8080;
             proxy_set_header X-MEN-RequestID $requestid;
         }


### PR DESCRIPTION
When I was listing the deployments from the API, I found the `headers.link`in the response which represents internal url, it should be relative url such as `/deployments?page=2&per_page=20` or full url like this `https://example.com/api/management/v1/deployments/deployments?page=2&per_page=20`, but it responded:

```
link: '<http://mender-deployments:8080/api/management/v1/deployments/deployments?page=2&per_page=20>; rel="next", <http://mender-deployments:8080/api/management/v1/deployments/deployments?page=1&per_
page=20>; rel="first"',
```

Expected relative or absolute url:

```
link: '</api/management/v1/deployments/deployments?page=2&per_page=20>; rel="next", </api/management/v1/deployments/deployments?page=1&per_
page=20>; rel="first"',
```

ref. https://tools.ietf.org/html/rfc5988