### PR TITLE
nginx.conf: disable http2

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -56,7 +56,7 @@ http {
     }
 
     server {
-        listen 443 ssl http2;
+        listen 443 ssl;
         server_name @ALLOWED_HOSTS@;
 
         include /usr/local/openresty/nginx/conf/optional/endpoints/*.conf;


### PR DESCRIPTION
temporary, because of:
https://tracker.mender.io/browse/MEN-2386

will be researched in:
https://tracker.mender.io/browse/MEN-2407

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>