### PR TITLE
nginx.conf: disable Strict Transport Security by default

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -93,7 +93,7 @@ http {
             return 400;
         }
 
-        add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+        add_header Strict-Transport-Security "max-age=0; includeSubdomains; preload";
         add_header X-Frame-Options DENY;
         add_header X-Content-Type-Options nosniff;
 


### PR DESCRIPTION
new browsers have strict checks and won't allow the self-signed cert
when hsts is on (no way to override this). this means no access in
demo environment.

set the max-age to 0 to reset/disable hsts, and allow users to
override ssl warnings in demo environments.

note that production template config still has hsts - certs must be
valid in production so that's not an issue.

changelog: none

Signed-off-by: Marcin Chalczynski <m.chalczynski@gmail.com>

https://tracker.mender.io/browse/MEN-2440