### PR TITLE
add HTTP Strict Transport Security max-age setting

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,6 +75,13 @@ else
     sed -i -e "s/[@]LOGS_FORMAT[@]/main/g" /usr/local/openresty/nginx/conf/nginx.conf
 fi
 
+# HTTP Strict Transport Security max-age - 2yrs by default
+if [ -n "$HSTS_MAX_AGE" ]; then
+    sed -i -e "s/[@]HSTS_MAX_AGE[@]/$HSTS_MAX_AGE/" /usr/local/openresty/nginx/conf/nginx.conf
+else
+    sed -i -e "s/[@]HSTS_MAX_AGE[@]/63072000/" /usr/local/openresty/nginx/conf/nginx.conf
+fi
+
 DNS_NAMES=${DNS_NAMES:-mender-useradm mender-inventory mender-deployments \
                                       mender-device-auth mender-device-adm \
                                       mender-gui}

--- a/nginx.conf
+++ b/nginx.conf
@@ -93,7 +93,7 @@ http {
             return 400;
         }
 
-        add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+        add_header Strict-Transport-Security "max-age=@HSTS_MAX_AGE@; includeSubdomains; preload";
         add_header X-Frame-Options DENY;
         add_header X-Content-Type-Options nosniff;
 


### PR DESCRIPTION
make it possible to set different max-age for different envs.

demo will have 0, production (default, embedded config) will remain with 2yrs

https://tracker.mender.io/browse/MEN-2440