### PR TITLE
MC-301 ssl_trusted_certificate added.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -71,6 +71,7 @@ http {
         ssl_session_tickets off;
         ssl_stapling on;
         ssl_stapling_verify on;
+        ssl_trusted_certificate /var/www/mendersoftware/cert/cert.crt;
 
         # non https requests are redirected to https
         error_page 497 =301 https://$http_host$request_uri;


### PR DESCRIPTION
Adding ssl_trusted_certificate for the OCSP validation to work.

 . full description: https://tracker.mender.io/browse/MC-301

ChangeLog:title
Signed-off-by: Peter Grzybowski <peter@northern.tech>