### PR TITLE
POST to /api/management/v*/tenantadm/tenants is unauthenticated

### DIFF
--- a/tenantadm.nginx.conf
+++ b/tenantadm.nginx.conf
@@ -1,16 +1,15 @@
-location ~ /api/management/(v[0-9]+)/tenantadm{
-    auth_request /userauth;
-    auth_request_set $requestid $upstream_http_x_men_requestid;
-
-    proxy_pass http://mender-tenantadm:8080;
-    proxy_set_header X-MEN-RequestID $requestid;
-}
-
-location ~ /api/management/(v[0-9]+)/tenantadm/tenants{
-
+location ~ /api/management/(v[0-9]+)/tenantadm/tenants {
     if ($request_method != POST) {
         return 405;
     }
 
     proxy_pass http://mender-tenantadm:8080;
+}
+
+location ~ /api/management/(v[0-9]+)/tenantadm {
+    auth_request /userauth;
+    auth_request_set $requestid $upstream_http_x_men_requestid;
+
+    proxy_pass http://mender-tenantadm:8080;
+    proxy_set_header X-MEN-RequestID $requestid;
 }


### PR DESCRIPTION
tenantadm.conf: order of uri pattern matching matters, reorder stanzas
to avoid JWT token check request masking the public signup end-point.