### PR TITLE
MEN-3275 /api/management/v1/useradm/plan/verify endpoint

### DIFF
--- a/common.nginx.conf
+++ b/common.nginx.conf
@@ -89,6 +89,11 @@ location = /api/management/v1/useradm/auth/login {
 	proxy_pass http://mender-useradm:8080/api/management/v1/useradm/auth/login;
 }
 
+# user plan verify endpoint; MEN-3275 same as/login but check the pricing plan
+location = /api/management/v1/useradm/plan/verify {
+	proxy_pass http://mender-useradm:8080/api/internal/v1/useradm/plan/verify;
+}
+
 # exclude Device API endpoints from Management API routing
 # todo: remove with unifying routing
 location ~ /api/management/v1/deployments/device/.* {


### PR DESCRIPTION
A proposition to solve MEN-3275 [1]

 * passes data to /plan/verify [2]
 * needed for me-proxy PR [3]

[1] https://tracker.mender.io/browse/MEN-3275
[2] https://github.com/mendersoftware/useradm-enterprise/pull/40
[3] https://github.com/mendersoftware/sre-tools/pull/57

ChangeLog:title
Signed-off-by: Peter Grzybowski <peter@northern.tech>