### PR TITLE
MEN-3240 RBAC: per device group restrictions support

### DIFF
--- a/common.nginx.conf
+++ b/common.nginx.conf
@@ -72,10 +72,12 @@ location ~ /api/devices/v1/deployments/device/deployments/(?<depid>.*)/status {
 location ~ /api/devices/v1/inventory/device/attributes {
 	auth_request /devauth;
 	auth_request_set $requestid $upstream_http_x_men_requestid;
+	auth_request_set $rbac_groups $upstream_http_x_men_rbac_inventory_groups;
 
 	rewrite ^.*$ /api/0.1.0/attributes break;
 	proxy_pass http://mender-inventory:8080;
 	proxy_set_header X-MEN-RequestID $requestid;
+	proxy_set_header X-MEN-RBAC-Inventory-Groups $rbac_groups;
 }
 
 # the following locations are for requests to our APIs from UIs, etc
@@ -136,27 +138,33 @@ location = /api/management/v1/deployments/artifacts {
 location ~ /api/management/v1/deployments(?<endpoint>/.*) {
 	auth_request /userauth;
 	auth_request_set $requestid $upstream_http_x_men_requestid;
+	auth_request_set $rbac_groups $upstream_http_x_men_rbac_deployments_groups;
 
 	proxy_pass http://mender-deployments:8080;
 	proxy_set_header X-MEN-RequestID $requestid;
+	proxy_set_header X-MEN-RBAC-Deployments-Groups $rbac_groups;
 }
 
 # inventory
 location ~ /api/management/v1/inventory(?<endpoint>/.*) {
 	auth_request /userauth;
 	auth_request_set $requestid $upstream_http_x_men_requestid;
+	auth_request_set $rbac_groups $upstream_http_x_men_rbac_inventory_groups;
 
 	rewrite ^.*$ /api/0.1.0$endpoint break;
 	proxy_pass http://mender-inventory:8080;
 	proxy_set_header X-MEN-RequestID $requestid;
+	proxy_set_header X-MEN-RBAC-Inventory-Groups $rbac_groups;
 }
 
 location ~ /api/management/v2/inventory(?<endpoint>/.*) {
 	auth_request /userauth;
 	auth_request_set $requestid $upstream_http_x_men_requestid;
+	auth_request_set $rbac_groups $upstream_http_x_men_rbac_inventory_groups;
 
 	proxy_pass http://mender-inventory:8080;
 	proxy_set_header X-MEN-RequestID $requestid;
+	proxy_set_header X-MEN-RBAC-Inventory-Groups $rbac_groups;
 }
 
 # this is our verification endpoint definition (alias over /devauth/tokens/verify)
@@ -170,6 +178,17 @@ location = /devauth {
 }
 
 # case similar to /devauth but this time for user verification
+# This endpoint returns the following Headers:
+#  * X-MEN-RBAC-Inventory-Groups
+#  * X-MEN-RBAC-Deployments-Groups 
+#  They denote a comma separated list of device groups names that present user
+#  is allowed to access, from inventory and deployments respectively
+#  The subsequent calls from certain locations to 
+# 	 `auth_request_set $rbac_groups $upstream_http_x_men_rbac_inventory_groups;`
+# 	 `proxy_set_header X-MEN-RBAC-Inventory-Groups $rbac_groups;`
+# 	 `auth_request_set $rbac_groups $upstream_http_x_men_rbac_deployments_groups;`
+# 	 `proxy_set_header X-MEN-RBAC-Deployments-Groups $rbac_groups;`
+#  provide the endpoints with the information on device groups for RBAC
 location = /userauth {
 	internal;
 


### PR DESCRIPTION
Restricts the ability to deploy to groups defined via RBAC.

 * fills `X-MEN-RBAC-Deployments-Groups` header passed from [/verify/auth](https://github.com/mendersoftware/useradm-enterprise/pull/44/commits/b7275a3fc00205b728eb2874403148c0dddbb821#diff-58dcce776af1c084ee139709c64207cbR169)
 * the headers are used in [deployments](https://github.com/mendersoftware/deployments-enterprise/pull/93/commits/90d3b703e4a236eb7bd6a18b295f97850f914f30#diff-b96384965a3a7dfb6a3d0a58346afefbR507)
 * fills `X-MEN-RBAC-Inventory-Groups` for use in inventory upcoming restrictions on accessing devices

Design:
 * [RBAC_deploy_to_group](https://docs.google.com/document/d/14nJGvnGJ8lXGvdX9hooHkZen4DChHP0nPFva3Uz6mws/edit?usp=sharing)

Related ticket:
 * [MEN-3240](https://tracker.mender.io/browse/MEN-3240)

Related PRs:
 * https://github.com/mendersoftware/mender-api-gateway-docker/pull/117
 * https://github.com/mendersoftware/useradm-enterprise/pull/46
 * https://github.com/mendersoftware/deployments-enterprise/pull/93
 * https://github.com/mendersoftware/inventory-enterprise/pull/17
ChangeLog:title
Signed-off-by: Peter Grzybowski <peter@northern.tech>