### PR TITLE
Set X-Original-URI and X-Original-Method in /devauth

### DIFF
--- a/common.nginx.conf
+++ b/common.nginx.conf
@@ -180,6 +180,8 @@ location = /devauth {
 	proxy_pass http://mender-device-auth:8080/api/internal/v1/devauth/tokens/verify;
 	proxy_pass_request_body off;
 	proxy_set_header Content-Length "";
+	proxy_set_header X-Original-URI $request_uri;
+	proxy_set_header X-Original-Method $request_method;
 }
 
 # case similar to /devauth but this time for user verification


### PR DESCRIPTION
To enable URI/method-specific token verification features (e.g., throttling
or plan limitations), we add the X-Original-URI and X-Original-Method
headers in the token verification request used by auth_request.