### PR TITLE
MEN-3619: Forward host on oauth endpoints

### DIFF
--- a/common.nginx.conf
+++ b/common.nginx.conf
@@ -97,6 +97,11 @@ location = /api/management/v1/useradm/auth/login {
 	proxy_pass http://mender-useradm:8080/api/management/v1/useradm/auth/login;
 }
 
+location ~ /api/management/v1/useradm/oauth2/.* {
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_pass http://mender-useradm:8080;
+}
+
 # exclude Device API endpoints from Management API routing
 # todo: remove with unifying routing
 location ~ /api/management/v1/deployments/device/.* {


### PR DESCRIPTION
Necessary for mendersoftware/useradm-enterprise#89