### PR TITLE
config: handle 429 Too Many Requests

### DIFF
--- a/common.nginx.conf
+++ b/common.nginx.conf
@@ -114,6 +114,7 @@ location = /api/management/v1/inventory/device/attributes {
 
 # user administration
 location ~ /api/management/(v[0-9]+)/useradm/ {
+	error_page 500 =429 /429.json;
 	auth_request /userauth;
 	auth_request_set $requestid $upstream_http_x_men_requestid;
 
@@ -123,6 +124,7 @@ location ~ /api/management/(v[0-9]+)/useradm/ {
 
 # device authentication
 location ~ /api/management/(v[0-9]+)/devauth/ {
+	error_page 500 =429 /429.json;
 	auth_request /userauth;
 	auth_request_set $requestid $upstream_http_x_men_requestid;
 
@@ -132,6 +134,7 @@ location ~ /api/management/(v[0-9]+)/devauth/ {
 
 # deployments
 location = /api/management/v1/deployments/artifacts {
+	error_page 500 =429 /429.json;
 	auth_request /userauth;
 	auth_request_set $requestid $upstream_http_x_men_requestid;
 
@@ -152,6 +155,7 @@ location = /api/management/v1/deployments/artifacts {
 }
 
 location = /api/management/v1/deployments/artifacts/generate {
+	error_page 500 =429 /429.json;
 	auth_request /userauth;
 	auth_request_set $requestid $upstream_http_x_men_requestid;
 
@@ -167,6 +171,7 @@ location = /api/management/v1/deployments/artifacts/generate {
 }
 
 location ~ /api/management/v[0-9]+/deployments(?<endpoint>/.*) {
+	error_page 500 =429 /429.json;
 	auth_request /userauth;
 	auth_request_set $requestid $upstream_http_x_men_requestid;
 	auth_request_set $rbac_groups $upstream_http_x_men_rbac_deployments_groups;
@@ -178,6 +183,7 @@ location ~ /api/management/v[0-9]+/deployments(?<endpoint>/.*) {
 
 # inventory
 location ~ /api/management/v1/inventory(?<endpoint>/.*) {
+	error_page 500 =429 /429.json;
 	auth_request /userauth;
 	auth_request_set $requestid $upstream_http_x_men_requestid;
 	auth_request_set $rbac_groups $upstream_http_x_men_rbac_inventory_groups;
@@ -189,6 +195,7 @@ location ~ /api/management/v1/inventory(?<endpoint>/.*) {
 }
 
 location ~ /api/management/v2/inventory(?<endpoint>/.*) {
+	error_page 500 =429 /429.json;
 	auth_request /userauth;
 	auth_request_set $requestid $upstream_http_x_men_requestid;
 	auth_request_set $rbac_groups $upstream_http_x_men_rbac_inventory_groups;

--- a/tenantadm.nginx.conf
+++ b/tenantadm.nginx.conf
@@ -7,6 +7,7 @@ location ~ /api/management/(v[0-9]+)/tenantadm/tenants {
 }
 
 location ~ /api/management/(v[0-9]+)/tenantadm {
+	error_page 500 =429 /429.json;
     auth_request /userauth;
     auth_request_set $requestid $upstream_http_x_men_requestid;
 


### PR DESCRIPTION
Management endpoints can return 429 Too Many Requests when
throttling is enabled.

Nginx will translate them to 500 unfortunately; as a compromise,
translate all 500s to 429s, this way the client will
be able to see any 429s.