### PR TITLE
Allow Wildcard Servername '_'

### DIFF
--- a/common.nginx.conf
+++ b/common.nginx.conf
@@ -11,9 +11,6 @@ if ($http_origin = $scheme://$host) {
 if ($http_origin = $scheme://$host:$server_port) {
 	set $origin_valid 1;
 }
-if ($http_origin ~* ^((https?:\/\/)?(@ALLOWED_ORIGIN_HOSTS@))$) {
-	set $origin_valid 1;
-}
 if ($origin_valid = 0) {
 	return 400;
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,10 +30,6 @@ sed -i -e "s/[@]INCLUDE_SERVER_BLOCKS[@]/include \/usr\/local\/openresty\/nginx\
 if [ -n "$ALLOWED_HOSTS" ]; then
     sed -i -e "s/[@]ALLOWED_HOSTS[@]/$ALLOWED_HOSTS/" /usr/local/openresty/nginx/conf/ssl.nginx.conf
     sed -i -e "s/[@]ALLOWED_HOSTS[@]/$ALLOWED_HOSTS/" /usr/local/openresty/nginx/conf/non-ssl.nginx.conf
-
-    # generate ORIGIN whitelist
-    hosts=$(echo $ALLOWED_HOSTS | sed 's/ \{1,\}/|/g' | sed 's/[.]\{1,\}/\\\\\\./g')
-    sed -i -e "s/[@]ALLOWED_ORIGIN_HOSTS[@]/$hosts/" /usr/local/openresty/nginx/conf/common.nginx.conf
 else
    echo "ALLOWED_HOSTS undefined, exiting"
    exit 1


### PR DESCRIPTION
The http origin already gets checked by nginx with the `server_name` parameter in `non-ssl.nginx.conf` or `ssl.nginx.conf`.

The Problem is that if you set the ALLOWED_HOSTS variable to `_` which means wildcard for the nginx Server name, the origin check fails because the Regex is not valid anymore.

Signed-off-by: Felix Breuer <f.breuer94@gmail.com>