### PR TITLE
MEN-4118: restore ALLOWED_ORIGIN_HOSTS regex match when checking Origin

### DIFF
--- a/common.nginx.conf
+++ b/common.nginx.conf
@@ -11,6 +11,9 @@ if ($http_origin = $scheme://$host) {
 if ($http_origin = $scheme://$host:$server_port) {
 	set $origin_valid 1;
 }
+if ($http_origin ~* ^((https?:\/\/)?(@ALLOWED_ORIGIN_HOSTS@))$) {
+	set $origin_valid 1;
+}
 if ($origin_valid = 0) {
 	return 400;
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,6 +30,14 @@ sed -i -e "s/[@]INCLUDE_SERVER_BLOCKS[@]/include \/usr\/local\/openresty\/nginx\
 if [ -n "$ALLOWED_HOSTS" ]; then
     sed -i -e "s/[@]ALLOWED_HOSTS[@]/$ALLOWED_HOSTS/" /usr/local/openresty/nginx/conf/ssl.nginx.conf
     sed -i -e "s/[@]ALLOWED_HOSTS[@]/$ALLOWED_HOSTS/" /usr/local/openresty/nginx/conf/non-ssl.nginx.conf
+
+    # generate ORIGIN whitelist
+    if [ "$ALLOWED_HOSTS" != "_" ]; then
+        hosts=$(echo $ALLOWED_HOSTS | sed 's/ \{1,\}/|/g' | sed 's/[.]\{1,\}/\\\\\\./g')
+    else
+        hosts=".*"
+    fi
+    sed -i -e "s/[@]ALLOWED_ORIGIN_HOSTS[@]/$hosts/" /usr/local/openresty/nginx/conf/common.nginx.conf
 else
    echo "ALLOWED_HOSTS undefined, exiting"
    exit 1


### PR DESCRIPTION
If ALLOWED_ORIGIN_HOSTS is set to "_", the Origin header is not checked.

Changelog: title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>