### PR TITLE
MEN-4118: restore ALLOWED_ORIGIN_HOSTS regex match when checking Origin

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,11 @@ if [ -n "$ALLOWED_HOSTS" ]; then
     sed -i -e "s/[@]ALLOWED_HOSTS[@]/$ALLOWED_HOSTS/" /usr/local/openresty/nginx/conf/non-ssl.nginx.conf
 
     # generate ORIGIN whitelist
-    hosts=$(echo $ALLOWED_HOSTS | sed 's/ \{1,\}/|/g' | sed 's/[.]\{1,\}/\\\\\\./g')
+    if [ "$ALLOWED_HOSTS" != "_" ]; then
+        hosts=$(echo $ALLOWED_HOSTS | sed 's/ \{1,\}/|/g' | sed 's/[.]\{1,\}/\\\\\\./g')
+    else
+        hosts=".*"
+    fi
     sed -i -e "s/[@]ALLOWED_ORIGIN_HOSTS[@]/$hosts/" /usr/local/openresty/nginx/conf/common.nginx.conf
 else
    echo "ALLOWED_HOSTS undefined, exiting"


### PR DESCRIPTION
If ALLOWED_ORIGIN_HOSTS is set to "_", the Origin header is not checked.

Changelog: title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>
(cherry picked from commit c501ce7505528642870f1a33726535122fb6e6d5)
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>